### PR TITLE
Implement fullbrights according to tutorial on quakewiki.net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ COMMON_OBJS =	source/chase.o \
 	source/net_udp_psp2.o \
 	source/in_psp2.o \
 	source/gl_vidpsp2.o
+	source/gl_fullbright.o
 	
 CPPSOURCES	:= source/audiodec
 
@@ -98,3 +99,4 @@ $(TARGET).elf: $(OBJS)
 
 clean:
 	@rm -rf $(TARGET).velf $(TARGET).elf $(OBJS) $(TARGET).elf.unstripped.elf ../$(TARGET).vpk ../build/eboot.bin ../build/sce_sys/param.sfo ./param.sfo
+

--- a/source/gl_fullbright.c
+++ b/source/gl_fullbright.c
@@ -1,0 +1,45 @@
+//gl_fullbright.c
+#include "quakedef.h"
+//extern qboolean mtexenabled;
+int FindFullbrightTexture (byte *pixels, int num_pix)
+{
+	int i;
+	for (i = 0; i < num_pix; i++)
+	if (pixels[i] > 223)
+	return 1;
+	return 0;
+}
+void ConvertPixels (byte *pixels, int num_pixels)
+{
+	int i;
+	for (i = 0; i < num_pixels; i++)
+	if (pixels[i] < 224)
+	pixels[i] = 255;
+}
+void DrawFullBrightTextures (msurface_t *first_surf, int num_surfs)
+{
+	// gl_texsort 1 version
+	int i;
+	msurface_t *fa;
+	texture_t *t;
+	if (r_fullbright.value)
+	return;
+	//if (mtexenabled)
+	//return;
+	//GL_DisableMultitexture ();
+	for (fa = first_surf, i = 0; i < num_surfs; fa++, i++)
+	{
+		// find the correct texture
+		t = R_TextureAnimation (fa->texinfo->texture);
+		if (t->fullbright != -1 && fa->draw_this_frame)
+		{
+			glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+			glEnable (GL_BLEND);
+			GL_Bind (t->fullbright);
+			DrawGLPoly (fa->polys);
+			glDisable (GL_BLEND);
+			glBlendFunc (GL_ZERO, GL_SRC_COLOR);
+		}
+		fa->draw_this_frame = 0;
+	}
+}

--- a/source/gl_fullbright.h
+++ b/source/gl_fullbright.h
@@ -1,0 +1,5 @@
+//gl_fullbright.h
+#include "gl_model.h"
+int FindFullbrightTexture (byte *pixels, int num_pix);
+void DrawFullBrightTextures (msurface_t *first_surf, int num_surfs);
+void ConvertPixels (byte *pixels, int num_pixels);

--- a/source/gl_model.h
+++ b/source/gl_model.h
@@ -84,6 +84,7 @@ typedef struct texture_s
 	struct texture_s *anim_next;		// in the animation sequence
 	struct texture_s *alternate_anims;	// bmodels in frmae 1 use these
 	unsigned	offsets[MIPLEVELS];		// four mip maps stored
+	int			fullbright;
 } texture_t;
 
 
@@ -150,6 +151,7 @@ typedef struct msurface_s
 	int			cached_light[MAXLIGHTMAPS];	// values currently used in lightmap
 	bool	cached_dlight;				// true if dynamic light in cache
 	byte		*samples;		// [numstyles*surfsize]
+	int			draw_this_frame;
 } msurface_t;
 
 typedef struct mnode_s

--- a/source/gl_rsurf.c
+++ b/source/gl_rsurf.c
@@ -538,6 +538,8 @@ void R_RenderBrushPoly (msurface_t *fa)
 	else
 		DrawGLPoly (fa->polys);
 
+	fa->draw_this_frame = 1;
+
 	// add the poly to the proper lightmap chain
 
 	fa->polys->chain = lightmap_polys[fa->lightmaptexturenum];
@@ -785,6 +787,8 @@ void R_DrawBrushModel (entity_t *e)
 
 	R_BlendLightmaps ();
 
+	DrawFullBrightTextures (clmodel->surfaces, clmodel->numsurfaces);
+
 	glPopMatrix ();
 }
 
@@ -938,6 +942,8 @@ void R_DrawWorld (void)
 	DrawTextureChains ();
 
 	R_BlendLightmaps ();
+
+	DrawFullBrightTextures (cl.worldmodel->surfaces, cl.worldmodel->numsurfaces);
 
 }
 


### PR DESCRIPTION
This works now and it makes a huge difference! The lamps and red arrows look much better now, and they "glow in the dark" :)

It looks exactly like these images now. The red lights around the level 1 teleporter also look much more colorful now. 

Note fullbrights are used in A LOT of places and really make the game much more atmospheric. For example, the two small red lights on the secret wall in level 1 glow in the dark now. They highlight that wall even more when the light flickers dark. It looks really cool. The white lamps in level 1 also look much more realistic now. The buttons on the spiral stairway now light up in the dark and show the way.

This is a really innovative technique, such a simple trick, with such a large effect. I wish more games would have used this. Quake is amazing.


before (without fullbrights):
![](https://s10.postimg.org/uofail6ix/fullbrights_start_off.png)

now (with fullbrights):
![](https://s18.postimg.org/jxl6672a1/fullbrights_start_on.png)