### PR TITLE
fix gun position, 3 fullscreen modes (full, half, no HUD)

### DIFF
--- a/source/gl_screen.c
+++ b/source/gl_screen.c
@@ -80,8 +80,8 @@ float		scr_con_current;
 float		scr_conlines;		// lines of console to display
 
 float		oldscreensize, oldfov, oldsbaralpha;
-cvar_t		scr_viewsize = {"viewsize","120", true};
-cvar_t		scr_fov = {"fov","90"};	// 10 - 170
+cvar_t		viewsize = {"viewsize","100", true};
+cvar_t		fov = {"fov","90"};	// 10 - 170
 cvar_t		scr_conspeed = {"scr_conspeed","300"};
 cvar_t		scr_centertime = {"scr_centertime","2"};
 cvar_t		scr_sbaralpha = {"scr_sbaralpha", "0.50", true};
@@ -270,30 +270,35 @@ static void SCR_CalcRefdef (void)
 //========================================
 	
 // bound viewsize
-	if (scr_viewsize.value < 30)
+	if (viewsize.value < 30)
 		Cvar_Set ("viewsize","30");
-	if (scr_viewsize.value > 120)
+	if (viewsize.value > 120)
 		Cvar_Set ("viewsize","120");
 
 // bound field of view
-	if (scr_fov.value < 10)
+	if (fov.value < 10)
 		Cvar_Set ("fov","10");
-	if (scr_fov.value > 170)
+	if (fov.value > 170)
 		Cvar_Set ("fov","170");
 
 // intermission is always full screen	
 	if (cl.intermission)
 		size = 120;
 	else
-		size = scr_viewsize.value;
+		size = viewsize.value;
 
-	sb_lines = 48;
+	if (size >= 120)
+		sb_lines = 0;	// no status bar at all
+	else if (size >= 110)
+		sb_lines = 24;	// no inventory
+	else
+		sb_lines = 24+16+8;
 
-	if (scr_viewsize.value >= 100.0) {
+	if (viewsize.value >= 100.0) {
 		full = true;
 		size = 100.0;
 	} else
-		size = scr_viewsize.value;
+		size = viewsize.value;
 	if (cl.intermission)
 	{
 		full = true;
@@ -312,8 +317,8 @@ static void SCR_CalcRefdef (void)
 	}
 
 	r_refdef.vrect.height = vid.height * size;
-	if (r_refdef.vrect.height > vid.height - sb_lines)
-		r_refdef.vrect.height = vid.height - sb_lines;
+	//if (r_refdef.vrect.height > vid.height - sb_lines)
+	//	r_refdef.vrect.height = vid.height - sb_lines;
 	if (r_refdef.vrect.height > vid.height)
 			r_refdef.vrect.height = vid.height;
 	r_refdef.vrect.x = (vid.width - r_refdef.vrect.width)/2;
@@ -322,7 +327,7 @@ static void SCR_CalcRefdef (void)
 	else 
 		r_refdef.vrect.y = (h - r_refdef.vrect.height)/2;
 
-	r_refdef.fov_x = scr_fov.value;
+	r_refdef.fov_x = fov.value;
 	r_refdef.fov_y = CalcFov (r_refdef.fov_x, r_refdef.vrect.width, r_refdef.vrect.height);
 
 	scr_vrect = r_refdef.vrect;
@@ -338,7 +343,7 @@ Keybinding command
 */
 void SCR_SizeUp_f (void)
 {
-	Cvar_SetValue ("viewsize",scr_viewsize.value+10);
+	Cvar_SetValue ("viewsize",viewsize.value+10);
 	vid.recalc_refdef = 1;
 }
 
@@ -352,7 +357,7 @@ Keybinding command
 */
 void SCR_SizeDown_f (void)
 {
-	Cvar_SetValue ("viewsize",scr_viewsize.value-10);
+	Cvar_SetValue ("viewsize",viewsize.value-10);
 	vid.recalc_refdef = 1;
 }
 
@@ -366,8 +371,8 @@ SCR_Init
 void SCR_Init (void)
 {
 
-	Cvar_RegisterVariable (&scr_fov);
-	Cvar_RegisterVariable (&scr_viewsize);
+	Cvar_RegisterVariable (&fov);
+	Cvar_RegisterVariable (&viewsize);
 	Cvar_RegisterVariable (&scr_sbaralpha);
 	Cvar_RegisterVariable (&scr_conspeed);
 	Cvar_RegisterVariable (&scr_showram);
@@ -817,7 +822,7 @@ needs almost the entire 256k of stack space!
 */
 void SCR_UpdateScreen (void)
 {
-	static float	oldscr_viewsize;
+	static float	oldviewsize;
 	vrect_t		vrect;
 
 	if (block_drawing)
@@ -848,15 +853,15 @@ void SCR_UpdateScreen (void)
 	//
 	// determine size of refresh window
 	//
-	if (oldfov != scr_fov.value)
+	if (oldfov != fov.value)
 	{
-		oldfov = scr_fov.value;
+		oldfov = fov.value;
 		vid.recalc_refdef = true;
 	}
 
-	if (oldscreensize != scr_viewsize.value)
+	if (oldscreensize != viewsize.value)
 	{
-		oldscreensize = scr_viewsize.value;
+		oldscreensize = viewsize.value;
 		vid.recalc_refdef = true;
 	}
 	

--- a/source/menu.c
+++ b/source/menu.c
@@ -110,9 +110,6 @@ char		m_return_reason [32];
 #define	IPXConfig		(m_net_cursor == 2)
 #define	TCPIPConfig		(m_net_cursor == 3)
 
-CVAR (viewsize, 100, CVAR_ARCHIVE)
-CVAR (fov,		90,	 CVAR_ARCHIVE) // LIMITS: 10 - 170
-
 void M_ConfigureNetSubsystem(void);
 
 /*
@@ -1332,7 +1329,7 @@ void M_Options_Key (int k)
 		case 3: // Reset to defaults
 			Cbuf_AddText ("exec default.cfg\n");
 			IN_ResetInputs();
-			viewsize.value = 120;
+			viewsize.value = 100;
 			v_gamma.value = 1;
 			sensitivity.value = 3;
 			inverted.value = 0;

--- a/source/sbar.c
+++ b/source/sbar.c
@@ -905,8 +905,8 @@ void Sbar_Draw (void)
 
 	sb_updates++;
 
-	/*if (sb_lines && vid.width > 320) 
-		Draw_TileClear (0, vid.height - sb_lines, vid.width, sb_lines);*/
+	if (sb_lines && vid.width > 320 && r_refdef.vrect.height < vid.height - sb_lines)
+		Draw_TileClear (0, vid.height - sb_lines, vid.width, sb_lines);
 
 	if (sb_lines > 24)
 	{


### PR DESCRIPTION
This fixes issue https://github.com/Rinnegatamante/vitaQuake/issues/49

The gun position was a bug in VitaQuake: the Hexen ii style status bar caused a shift of the viewport. This shift was masked by a simultaneous bug in VitaGL, but showed itself after that bug was fixed.

In other words: there was a wrong calculation of the viewport height (it was clamped at “vid.height - sb_lines” instead of “vid.height” in fullscreen modes with viewsize >= 100).

I also re-enabled all three fullscreen modes again:
viewsize=100: fullscreen with full HUD (same as release 2.8, default, gun is at top of status bar)
viewsize=110: fullscreen with partial HUD (no inventory, gun is at top of status bar)
viewsize=120: fullscreen with no HUD (gun is at bottom of screen)

Note that the gun now moves correctly up and down when switching between these three fullscreen modes, as it should.