### PR TITLE
Update common.c

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -848,31 +848,6 @@ being registered.
 */
 void COM_CheckRegistered (void)
 {
-	int             h;
-	unsigned short  check[128];
-	int                     i;
-
-	COM_OpenFile("gfx/pop.lmp", &h);
-	static_registered = 0;
-
-	if (h == -1)
-	{
-#if WINDED
-	Sys_Error ("This dedicated server requires a full registered copy of Quake");
-#endif
-		Con_Printf ("Playing shareware version.\n");
-		if (com_modified)
-			Sys_Error ("You must have the registered version to use modified games");
-		return;
-	}
-
-	Sys_FileRead (h, check, sizeof(check));
-	COM_CloseFile (h);
-
-	for (i=0 ; i<128 ; i++)
-		if (pop[i] != (unsigned short)BigShort (check[i]))
-			Sys_Error ("Corrupted data file.");
-
 	Cvar_Set ("cmdline", com_cmdline);
 	Cvar_ForceSet ("registered", "1");
 	static_registered = 1;


### PR DESCRIPTION
removing pop.lmp check,because some mods/tc can be loaded without original quake files