### PR TITLE
Fix Makefile to work on both *NIX and Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,12 +85,12 @@ ASFLAGS = $(CFLAGS)
 all: $(TARGET).vpk
 
 $(TARGET).vpk: $(TARGET).velf
-	vita-make-fself -s $< build\eboot.bin
+	vita-make-fself -s $< build/eboot.bin
 	vita-mksfoex -s TITLE_ID=$(TITLE) "$(TARGET)" param.sfo
 	cp -f param.sfo build/sce_sys/param.sfo
 	
 	#------------ Comment this if you don't have 7zip ------------------
-	7z a -tzip ./$(TARGET).vpk -r .\build\sce_sys\* .\build\eboot.bin .\build\shaders\*
+	7z a -tzip ./$(TARGET).vpk -r ./build/sce_sys ./build/eboot.bin ./build/shaders
 	#-------------------------------------------------------------------
 	
 %.velf: %.elf
@@ -102,4 +102,4 @@ $(TARGET).elf: $(OBJS)
 	$(CXX) $(CXXFLAGS) $^ $(LIBS) -o $@
 
 clean:
-	@rm -rf $(TARGET).velf $(TARGET).elf $(OBJS) $(TARGET).elf.unstripped.elf ../$(TARGET).vpk ../build/eboot.bin ../build/sce_sys/param.sfo ./param.sfo
+	@rm -rf $(TARGET).velf $(TARGET).elf $(OBJS) $(TARGET).elf.unstripped.elf $(TARGET).vpk build/eboot.bin build/sce_sys/param.sfo ./param.sfo


### PR DESCRIPTION
Also fixed paths for clean

* Change \ in paths to /
* Drop wildcard from 7zip, not needed since recursive is specified and gets expanded by the shell if using /*

Tested working on Linux (Ubuntu 17.10) and Windows 10, both produce the same VPK.